### PR TITLE
Updating eslint-config-airbnb to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "url": "https://gitlab.com/t_etor/mathetats/issues"
   },
   "homepage": "https://gitlab.com/t_etor/mathetats#README",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "babel": "^6.5.2",
     "babel-cli": "^6.8.0",
@@ -29,7 +31,7 @@
     "chai": "^3.5.0",
     "codecov": "^1.0.1",
     "eslint": "^2.9.0",
-    "eslint-config-airbnb": "^8.0.0",
+    "eslint-config-airbnb": "^9.0.0",
     "eslint-plugin-import": "^1.7.0",
     "eslint-plugin-jsx-a11y": "^1.2.0",
     "eslint-plugin-react": "^5.0.1",


### PR DESCRIPTION
Please update [eslint-config-airbnb](https://npmjs.org/package/eslint-config-airbnb) to version 9.0.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.
